### PR TITLE
Wrong config path in READMe.md file and missing lines in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ python train.py
 ### Training of L2I
 Modify the `config` in `train.py` :
 ```
-config = 'configs/controlnet/DODA_wheat_ldm_kl_4_layout_clip.yaml'
+config = 'configs/DODA/DODA_wheat_ldm_kl_4_layout_clip.yaml'
 ```
 Modify the `resume_path` in `train.py` to the weight path of your ldm or the ldm provided by us.
-Modify the `txt_file` and `data_root` in the config file to the path of the filenames txt file and the path to your own dataset.
+Modify the `txt_file` and `data_root` in the config file to the path of the filenames of conditioned .txt files (e.g., train_cldm.txt and val_cldm.txt) and the path to your own dataset.
 then train the cldm by running:
 ```
 python train.py

--- a/configs/DODA/DODA_wheat_ldm_kl_4_layout_clip.yaml
+++ b/configs/DODA/DODA_wheat_ldm_kl_4_layout_clip.yaml
@@ -84,12 +84,16 @@ data:
     train:
       target: utils.wheat_dataset_correct.wheatConditionalTrain
       params:
+        txt_file: "datasets/wheat/train_cldm.txt"
+        data_root: "datasets/wheat"
         ag_rate: 0.8
         flip_p: 0.5
         size: 256
     validation:
       target: utils.wheat_dataset_correct.wheatConditionalValidation
       params:
+        txt_file: "datasets/wheat/val_cldm.txt"
+        data_root: "datasets/wheat"
         ag_rate: 0
         flip_p: 0
         size: 256


### PR DESCRIPTION
## README.md - Training of L2I 

The mentioned config path in the README.md documentation file does not exist. At this stage, we will be using the config file in the `DODA` directory. The path should be refined as follows:

```
config = 'configs/DODA/DODA_wheat_ldm_kl_4_layout_clip.yaml'
```

## Missing arguments in the config file

In the `DODA_wheat_ldm_kl_4_layout_clip.yaml` config file, `txt_file` and `data_root` arguments for our dataset are missing. As I suppose in this stage we will be using image layouts in the dataset/source directory, I suppose we will the using `train_cldm.txt` and `val_cldm.txt` files in this stage, making the training conditioned of layout images? Therefore, I believe the config file could be updated as follows:

```
data:
  target: utils.utils.DataloaderFromConfig
  params:
    batch_size: 16
    num_workers: 4
    train:
      target: utils.wheat_dataset_correct.wheatConditionalTrain
      params:
        txt_file: "datasets/wheat/train_cldm.txt"
        data_root: "datasets/wheat"
        ag_rate: 0.8
        flip_p: 0.5
        size: 256
    validation:
      target: utils.wheat_dataset_correct.wheatConditionalValidation
      params:
        txt_file: "datasets/wheat/val_cldm.txt"
        data_root: "datasets/wheat"
        ag_rate: 0
        flip_p: 0
        size: 256
```